### PR TITLE
Add support for Laravel 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",       
-        "illuminate/database": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*",
-        "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*"
+        "php": ">=5.5.0",
+        "illuminate/database": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*",
+        "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8 || ~5.0",


### PR DESCRIPTION
Simply adds laravel 5.6 to the require list for Illuminate packages.